### PR TITLE
Stricter checks for FlxG.bitmap.maxTextureSize (#3279)

### DIFF
--- a/flixel/graphics/FlxGraphic.hx
+++ b/flixel/graphics/FlxGraphic.hx
@@ -634,6 +634,15 @@ class FlxGraphic implements IFlxDestroyable
 			bitmap = value;
 			width = bitmap.width;
 			height = bitmap.height;
+
+			#if FLX_OPENGL_AVAILABLE
+			var max:Int = FlxG.bitmap.maxTextureSize;
+			if (max != -1)
+			{
+				if (width > max || height > max)
+					FlxG.log.warn('Graphic dimensions (${width}x${height}) exceed the maximum allowed size (${max}x${max}), which may cause rendering issues.');
+			}
+			#end
 		}
 
 		return value;

--- a/flixel/system/frontEnds/BitmapFrontEnd.hx
+++ b/flixel/system/frontEnds/BitmapFrontEnd.hx
@@ -8,7 +8,7 @@ import flixel.math.FlxRect;
 import flixel.system.FlxAssets.FlxGraphicAsset;
 import flixel.util.FlxColor;
 import openfl.Assets;
-#if !flash
+#if FLX_OPENGL_AVAILABLE
 import lime.graphics.opengl.GL;
 #end
 
@@ -19,9 +19,13 @@ import lime.graphics.opengl.GL;
  */
 class BitmapFrontEnd
 {
-	#if !flash
+	#if FLX_OPENGL_AVAILABLE
 	/**
-	 * Gets max texture size for native targets
+	 * Returns the maximum allowed width and height (in pixels) for a texture.
+	 * This value is only available on hardware-accelerated targets that use OpenGL.
+	 * On unsupported targets, the returned value will always be -1.
+	 * 
+	 * @see https://opengl.gpuinfo.org/displaycapability.php?name=GL_MAX_TEXTURE_SIZE
 	 */
 	public var maxTextureSize(get, never):Int;
 	#end
@@ -391,10 +395,13 @@ class BitmapFrontEnd
 		}
 	}
 
-	#if !flash
+	#if FLX_OPENGL_AVAILABLE
 	function get_maxTextureSize():Int
 	{
-		return cast GL.getParameter(GL.MAX_TEXTURE_SIZE);
+		if (FlxG.stage.window.context.attributes.hardware)
+			return cast GL.getParameter(GL.MAX_TEXTURE_SIZE);
+		
+		return -1;
 	}
 	#end
 

--- a/flixel/system/macros/FlxDefines.hx
+++ b/flixel/system/macros/FlxDefines.hx
@@ -86,6 +86,7 @@ private enum HelperDefines
 	FLX_HEALTH;
 	FLX_NO_TRACK_POOLS;
 	FLX_NO_TRACK_GRAPHICS;
+	FLX_OPENGL_AVAILABLE;
 }
 
 class FlxDefines
@@ -251,6 +252,12 @@ class FlxDefines
 		
 		if (defined(FLX_DEBUG))
 			define(FLX_TRACK_GRAPHICS);
+
+		#if (lime_opengl || lime_opengles || lime_webgl)
+		// FlxG.stage.window.context.attributes.hardware is not always defined during unit tests
+		if (defined(FLX_NO_UNIT_TEST))
+			define(FLX_OPENGL_AVAILABLE);
+		#end
 		
 		defineInversion(FLX_TRACK_GRAPHICS, FLX_NO_TRACK_GRAPHICS);
 	}


### PR DESCRIPTION
* Stricter checks for FlxG.bitmap.maxTextureSize

* Add FLX_OPENGL_AVAILABLE define

* Adjust comment

* FlxGraphic: warn if size exceeds max

* fix unit tests

---------